### PR TITLE
Ignore DNS records which aren't type TXT

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -330,7 +330,7 @@ func findTxtRecord(client *GoDNSMadeEasy.GoDMEConfig, domainID int, zone, fqdn s
 	}
 
 	for _, existingRecord := range records {
-		if existingRecord.Name == name {
+		if existingRecord.Name == name && existingRecord.Type == "TXT" {
 			fmt.Printf("DNS record found: %v\n", existingRecord)
 			return &existingRecord
 		}


### PR DESCRIPTION
Fixes #45 -- things break if there is a _acme-challenge record which isn't a TXT